### PR TITLE
Implicit conversion between refs only available if types are related

### DIFF
--- a/jnipp.h
+++ b/jnipp.h
@@ -33,6 +33,7 @@
 #elif defined(JNIPP_USE_TYPE_TRAITS)
     #include <type_traits>
     #define JNIPP_ENABLE_IF_C std::enable_if
+    #define JNIPP_ENABLE_IF_T std::enable_if_t
     #define JNIPP_IS_BASE_OF std::is_base_of
 #endif
 
@@ -558,7 +559,11 @@ public:
     RefBase(const RefBase<T>& value) : _impl((jobject)value) {
     }
     // @TODO: how do we access value._impl ?
+    #if defined(JNIPP_ENABLE_IF_T)
+    template <typename S, typename = JNIPP_ENABLE_IF_T<JNIPP_IS_BASE_OF<T, S>::value>>
+    #else
     template <typename S>
+    #endif
     RefBase(const RefBase<S>& value) : _impl( static_cast<T>(value.__impl()) ) {
     }
     //template <typename S>

--- a/jnipp.h
+++ b/jnipp.h
@@ -559,7 +559,7 @@ public:
     }
     // @TODO: how do we access value._impl ?
     template <typename S>
-    RefBase(const RefBase<S>& value) : _impl( static_cast<S>(value.__impl()) ) {
+    RefBase(const RefBase<S>& value) : _impl( static_cast<T>(value.__impl()) ) {
     }
     //template <typename S>
     //Ref(const Ref<S>& value) : _impl((jobject)value) {


### PR DESCRIPTION
If type traits are enabled, make the conversion constructor on ref class only available for classes which are convertable (target is superclass of subject of conversion). Makes the library a lot more safe to use.